### PR TITLE
Auto-Initialize the API

### DIFF
--- a/lib/api/core/OpenAPI.ts
+++ b/lib/api/core/OpenAPI.ts
@@ -37,6 +37,7 @@ export type OpenAPIConfig = {
     request: Interceptors<RequestInit>;
     response: Interceptors<Response>;
   };
+  INITIALIZED: boolean;
 };
 
 export const OpenAPI: OpenAPIConfig = {
@@ -53,4 +54,5 @@ export const OpenAPI: OpenAPIConfig = {
     request: new Interceptors(),
     response: new Interceptors(),
   },
+  INITIALIZED: false,
 };

--- a/lib/api/core/request.ts
+++ b/lib/api/core/request.ts
@@ -1,3 +1,4 @@
+import { init } from "../../config";
 import { ApiError } from "./ApiError";
 import type { ApiRequestOptions } from "./ApiRequestOptions";
 import type { ApiResult } from "./ApiResult";
@@ -348,6 +349,11 @@ export const request = <T>(
   config: OpenAPIConfig,
   options: ApiRequestOptions<T>,
 ): CancelablePromise<T> => {
+  // Verify that config has been initialized
+  if (!config.INITIALIZED) {
+    init();
+  }
+
   return new CancelablePromise(async (resolve, reject, onCancel) => {
     try {
       const url = getUrl(config, options);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -62,6 +62,9 @@ export const init = (
       return await getToken();
     },
   });
+
+  // Mark OpenAPI as initialized
+  OpenAPI.INITIALIZED = true;
 };
 
 function _merge(target: object = {}, ...objects: object[]): object {

--- a/readme.md
+++ b/readme.md
@@ -28,23 +28,33 @@ The following ENV variables are required to run the project:
 ## Usage
 
 ```js
-import { Users, init } from "@kinde/management-api-js";
+import { Users } from "@kinde/management-api-js";
 
-init();
 const { users } = await Users.getUsers();
 ```
 
 ### Params can be passed to the function as an object
 
 ```js
-import { Users, init } from "@kinde/management-api-js";
+import { Users } from "@kinde/management-api-js";
 
 const params = {
   id: "kp_xxx",
 };
 
-init();
 const userData = await Users.getUserData(params);
+```
+
+### Manually Initializing the API
+
+```js
+import { init } from "@kinde/management-api-js";
+
+init({
+  domain: "mybusiness.kinde.com",
+  clientId: "client_id",
+  clientSecret: "client_secret",
+});
 ```
 
 ## API documentation


### PR DESCRIPTION
This allows developers to call the API without manually initializing. This does not prevent manual initialization from occurring, nor does it override it. This also shows a proper error if the API cannot initialize, instead of showing non-informative failed API responses.

# Additions

## Initialization Tracking

A boolean flag is added to `OpenAPI` (and its type `OpenAPIConfig`). The flag defaults to false, entertaining a lazy auto-initialization strategy. This is a better initialization strategy than immediate initialization, since it gives the developer the option to initialize manually before using the API. Further, lazy auto-initialization prevents creating a token unnecessarily, should the developer choose to manually initialize.

## Auto-Initialization on Request

When `request` is called (aka `__request` as used in the generated API file), initialization is verified via the boolean flag. If the configuration has not yet been initialized, initialization occurs. The request then proceeds as normal. This impacts performance minimally, as it merely shifts the time of initialization to the beginning of the first request and adds a single boolean check otherwise.

# Benefits

The current state of the package (v0.9.0) causes silent and misleading failures surrounding initialization. If `init` is not called before the first API request, the package will throw an `Invalid URL` error due to the default URL value `https://{your_subdomain}.kinde.com`. This doesn't suggest that the environment isn't correctly set up, nor does it suggest that `init` has not yet been called.

With auto-initialization, `init` will be called regardless, leading to more informed debugging when the environment is not set up properly. Instead of `Invalid URL`, developers might see `kindeDomain or env KINDE_DOMAIN is not set`.

Further, `init` is boilerplate for developers that store the domain and other parameters in the environment. It is helpful to the development process to handle it in the background. However, leaving it available for manual initialization when needed is good for the manually-set use case and backwards compatibility.

# Checklist

- [ x ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ x ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).