### PR TITLE
feat: kinde domain can de defined with or without the https://

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -45,13 +45,19 @@ export const init = (
     throw new Error("kindeDomain or env KINDE_DOMAIN is not set");
   }
 
+  // KINDE_DOMAIN needs to be prefixed with https:// add it if it's not there
+  let domain = process.env.KINDE_DOMAIN || config.kindeDomain;
+  if (!domain.startsWith("https://")) {
+    domain = "https://" + domain;
+  }
+
   _merge(
     kindeConfig,
     {
       clientId: process.env.KINDE_MANAGEMENT_CLIENT_ID,
       clientSecret: process.env.KINDE_MANAGEMENT_CLIENT_SECRET,
-      audience: process.env.KINDE_DOMAIN + "/api",
-      kindeDomain: process.env.KINDE_DOMAIN,
+      audience: domain + "/api",
+      kindeDomain: domain,
     },
     config,
   );


### PR DESCRIPTION
# Explain your changes

Documentation suggests to supply the domain without the https://, this PR allows the domain to be supplied with or without the https

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
