### PR TITLE
bug: adds saml:okta to types

### DIFF
--- a/lib/api/types.gen.ts
+++ b/lib/api/types.gen.ts
@@ -2612,6 +2612,7 @@ export type CreateConnectionData = {
       | "oauth2:twitter"
       | "oauth2:xero"
       | "saml:custom"
+      | "saml:okta"
       | "wsfed:azure_ad";
     /**
      * Client IDs of applications in which this connection is to be enabled.

--- a/spec/kinde-mgmt-api-specs.yaml
+++ b/spec/kinde-mgmt-api-specs.yaml
@@ -1928,6 +1928,7 @@ paths:
                     - oauth2:twitter
                     - oauth2:xero
                     - saml:custom
+                    - saml:okta
                     - wsfed:azure_ad
                   nullable: false
                 enabled_applications:


### PR DESCRIPTION
# Explain your changes

Adds `saml:okta` as a supported connection strategy type for the `CreateConnection` endpoint. This extends the available SAML connection options alongside the existing `saml:custom` type.

**Changes:**
- Updated `spec/kinde-mgmt-api-specs.yaml` to include `saml:okta` in the strategy enum
- Updated `lib/api/types.gen.ts` with the regenerated type definition

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._