### PR TITLE
fix(security): upgrade vite 7.3.1 → 7.3.2 (3 CVEs patched)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@vitest/coverage-v8": "^4.0.0",
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.0.18",
     "vitest-fetch-mock": "^0.4.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,11 +37,11 @@ importers:
         specifier: ^5.4.5
         version: 5.8.3
       vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)
+        specifier: ^7.3.2
+        version: 7.3.2(@types/node@24.10.13)(jiti@2.6.1)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@24.10.13)(rollup@4.57.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1))
+        version: 4.5.4(@types/node@24.10.13)(rollup@4.57.1)(typescript@5.8.3)(vite@7.3.2(@types/node@24.10.13)(jiti@2.6.1))
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)
@@ -1063,8 +1063,8 @@ packages:
       vite:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1496,13 +1496,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1))':
+  '@vitest/mocker@4.0.18(vite@7.3.2(@types/node@24.10.13)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)
+      vite: 7.3.2(@types/node@24.10.13)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -2066,7 +2066,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-plugin-dts@4.5.4(@types/node@24.10.13)(rollup@4.57.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)):
+  vite-plugin-dts@4.5.4(@types/node@24.10.13)(rollup@4.57.1)(typescript@5.8.3)(vite@7.3.2(@types/node@24.10.13)(jiti@2.6.1)):
     dependencies:
       '@microsoft/api-extractor': 7.56.3(@types/node@24.10.13)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
@@ -2079,13 +2079,13 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.8.3
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)
+      vite: 7.3.2(@types/node@24.10.13)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1):
+  vite@7.3.2(@types/node@24.10.13)(jiti@2.6.1):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2105,7 +2105,7 @@ snapshots:
   vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1))
+      '@vitest/mocker': 4.0.18(vite@7.3.2(@types/node@24.10.13)(jiti@2.6.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -2122,7 +2122,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)
+      vite: 7.3.2(@types/node@24.10.13)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.13


### PR DESCRIPTION
## Summary

Clean replacement for #136 (which has merge conflicts against the current `main`).

Upgrades `vite` from **7.3.1 → 7.3.2** - a patch-only security release.  
No API changes, no migration required. All 51 tests pass.

---

## Security vulnerabilities fixed

| CVE | GHSA | CVSS | Severity | Description |
|-----|------|------|----------|-------------|
| CVE-2026-39364 | [GHSA-v2wj-q39q-566r](https://github.com/advisories/GHSA-v2wj-q39q-566r) | 8.2 | **High** | `server.fs.deny` bypassed via `?raw` / `?import&raw` query params |
| CVE-2026-39365 | [GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9) | 6.3 | Medium | Path traversal in optimised deps `.map` handling |
| CVE-2026-39363 | [GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583) | 8.2 | **High** | Arbitrary file read via Vite dev server WebSocket (`fetchModule`) |

> **Impact scope**: All three CVEs only affect dev servers **explicitly exposed to the network** via `--host` / `server.host`. `vite` is a `devDependency` here and is never shipped to end users.

---

## Changes

- `package.json`: specifier bumped `^7.3.1` → `^7.3.2` (enforces the security floor)
- `pnpm-lock.yaml`: lockfile updated - vite resolves to `7.3.2`

## Migration required?

**No.** This is a semver patch release. Zero breaking changes. Zero API changes.

---

Supersedes: #136