### PR TITLE
chore(deps): upgrade typescript 5.8.3 to 5.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
     "prettier": "^3.2.5",
-    "typescript": "^5.4.5",
+    "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,10 +20,10 @@ importers:
     devDependencies:
       '@hey-api/client-fetch':
         specifier: ^0.12.0
-        version: 0.12.0(@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.8.3))
+        version: 0.12.0(@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.9.3))
       '@hey-api/openapi-ts':
         specifier: ^0.71.1
-        version: 0.71.1(magicast@0.3.5)(typescript@5.8.3)
+        version: 0.71.1(magicast@0.3.5)(typescript@5.9.3)
       '@types/node':
         specifier: ^24.0.0
         version: 24.10.14
@@ -34,14 +34,14 @@ importers:
         specifier: ^3.2.5
         version: 3.5.3
       typescript:
-        specifier: ^5.4.5
-        version: 5.8.3
+        specifier: ^5.9.3
+        version: 5.9.3
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@24.10.14)(jiti@2.6.1)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@24.10.14)(rollup@4.57.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.14)(jiti@2.6.1))
+        version: 4.5.4(@types/node@24.10.14)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.14)(jiti@2.6.1))
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.10.14)(jiti@2.6.1)
@@ -1028,8 +1028,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1252,9 +1252,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@hey-api/client-fetch@0.12.0(@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.8.3))':
+  '@hey-api/client-fetch@0.12.0(@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.9.3))':
     dependencies:
-      '@hey-api/openapi-ts': 0.71.1(magicast@0.3.5)(typescript@5.8.3)
+      '@hey-api/openapi-ts': 0.71.1(magicast@0.3.5)(typescript@5.9.3)
 
   '@hey-api/json-schema-ref-parser@1.0.6':
     dependencies:
@@ -1263,7 +1263,7 @@ snapshots:
       js-yaml: 4.1.1
       lodash: 4.17.21
 
-  '@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.8.3)':
+  '@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.9.3)':
     dependencies:
       '@hey-api/json-schema-ref-parser': 1.0.6
       ansi-colors: 4.1.3
@@ -1271,7 +1271,7 @@ snapshots:
       color-support: 1.1.3
       commander: 13.0.0
       handlebars: 4.7.8
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - magicast
 
@@ -1556,7 +1556,7 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/language-core@2.2.0(typescript@5.8.3)':
+  '@vue/language-core@2.2.0(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.28
@@ -1567,7 +1567,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   '@vue/shared@3.5.28': {}
 
@@ -2049,7 +2049,7 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.8.3: {}
+  typescript@5.9.3: {}
 
   ufo@1.6.1: {}
 
@@ -2066,18 +2066,18 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-plugin-dts@4.5.4(@types/node@24.10.14)(rollup@4.57.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.14)(jiti@2.6.1)):
+  vite-plugin-dts@4.5.4(@types/node@24.10.14)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.14)(jiti@2.6.1)):
     dependencies:
       '@microsoft/api-extractor': 7.56.3(@types/node@24.10.14)
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 2.2.0(typescript@5.8.3)
+      '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
       debug: 4.4.3
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
-      typescript: 5.8.3
+      typescript: 5.9.3
     optionalDependencies:
       vite: 7.3.1(@types/node@24.10.14)(jiti@2.6.1)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Clean replacement for #124 (which has merge conflicts against the current `main`).

Upgrades `typescript` from **5.8.3 to 5.9.3** (minor version bump).
No migration required. Zero type errors (`tsc --noEmit` clean). All 51 tests pass.

---

## Is this a breaking change?

**No migration needed for this codebase.** Here is the full Breaking Changes Specialist assessment:

### TS 5.9 breaking changes and their impact on this repo

| Breaking Change | Impact on this repo |
|---|---|
| `importsNotUsedAsValues` and `preserveValueImports` fully REMOVED (error TS5102) | **Not affected** - neither option is in `tsconfig.json` |
| `lib.d.ts` `ArrayBuffer`/`Buffer` hierarchy change (`Buffer` no longer assignable to `Uint8Array<ArrayBufferLike>`) | **Not affected** - `tsc --noEmit` passes with 0 errors |
| Type argument inference tightening (potential new errors in generic code) | **Not affected** - `tsc --noEmit` passes with 0 errors |
| Removed legacy options: `target: ES3`, `keyofStringsOnly`, `charset`, `out`, etc. | **Not affected** - `tsconfig.json` uses none of these |

### New features in TypeScript 5.9 (additive, no action required)
- `import defer` syntax support for deferred module evaluation
- `--module node20` stable option
- Summary descriptions in DOM APIs
- Expandable hover tooltips (preview, editor-only)
- Performance optimizations (type instantiation caching, ~11% speed-up in large projects)

---

## Changes

- `package.json`: specifier bumped `^5.4.5` to `^5.9.3` (enforces 5.9.3 as the floor)
- `pnpm-lock.yaml`: lockfile updated - typescript resolves to `5.9.3`

---

Supersedes: #124