### PR TITLE
chore(deps): upgrade prettier 3.5.3 to 3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@hey-api/openapi-ts": "^0.71.1",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.8.3",
     "typescript": "^5.4.5",
     "vite": "^7.3.1",
     "vite-plugin-dts": "^4.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.18(vitest@4.0.18(@types/node@24.10.14)(jiti@2.6.1))
       prettier:
-        specifier: ^3.2.5
-        version: 3.5.3
+        specifier: ^3.8.3
+        version: 3.8.3
       typescript:
         specifier: ^5.4.5
         version: 5.8.3
@@ -917,8 +917,8 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1941,7 +1941,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@3.5.3: {}
+  prettier@3.8.3: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Summary

Clean replacement for #123 (which has merge conflicts against the current `main`).

Upgrades `prettier` from **3.5.3 to 3.8.3** (minor version bump).
No migration required. All existing files already pass `prettier --check` with 3.8.3. All 51 tests pass.

---

## Is this a breaking change?

**No.** Prettier is a `devDependency` (code formatter) that is never shipped in the published package. The only possible "breaking" impact of a prettier upgrade is that it might format existing files differently, causing the `lint` script to fail. This was explicitly verified:

```
pnpm lint  =>  All matched files use Prettier code style!
```

Zero files needed reformatting. The new version formats this codebase identically to 3.5.3.

---

## Key changes across 3.6.0 - 3.8.3

All changes are formatting bug fixes and improvements - no API removals, no config option changes:

- **3.6.0**: New formatting features and improvements
- **3.7.0**: Additional formatting improvements
- **3.7.1**: Fix performance regression in doc printer (large file formatting speed)
- **3.7.2**: Fix string quote handling and HTML embedded attribute values
- **3.7.3**: Fix `getFileInfo()` regression that broke the VSCode extension
- **3.7.4**: Fix TypeScript comment duplication in union types
- **3.8.0**: Further formatting improvements
- **3.8.1-3.8.3**: Patch fixes

---

## Changes

- `package.json`: specifier bumped `^3.2.5` to `^3.8.3`
- `pnpm-lock.yaml`: lockfile updated - prettier resolves to `3.8.3`

---

Supersedes: #123