### PR TITLE
chore(deps): upgrade @hey-api/client-fetch 0.12.0 to 0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "spec:generate": "openapi-ts"
   },
   "devDependencies": {
-    "@hey-api/client-fetch": "^0.12.0",
+    "@hey-api/client-fetch": "^0.13.0",
     "@hey-api/openapi-ts": "^0.71.1",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 17.3.1
     devDependencies:
       '@hey-api/client-fetch':
-        specifier: ^0.12.0
-        version: 0.12.0(@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.8.3))
+        specifier: ^0.13.0
+        version: 0.13.1(@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.8.3))
       '@hey-api/openapi-ts':
         specifier: ^0.71.1
         version: 0.71.1(magicast@0.3.5)(typescript@5.8.3)
@@ -228,8 +228,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hey-api/client-fetch@0.12.0':
-    resolution: {integrity: sha512-/iZ6dhs39N0kjzCa9tlNeLNufVUd8zzv/wI1ewQt5AEHaVuDnAxvuQT+fRIPYkfIWKR3gVZKRp5mcCo29voYzQ==}
+  '@hey-api/client-fetch@0.13.1':
+    resolution: {integrity: sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA==}
     deprecated: Starting with v0.73.0, this package is bundled directly inside @hey-api/openapi-ts.
     peerDependencies:
       '@hey-api/openapi-ts': < 2
@@ -1252,7 +1252,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@hey-api/client-fetch@0.12.0(@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.8.3))':
+  '@hey-api/client-fetch@0.13.1(@hey-api/openapi-ts@0.71.1(magicast@0.3.5)(typescript@5.8.3))':
     dependencies:
       '@hey-api/openapi-ts': 0.71.1(magicast@0.3.5)(typescript@5.8.3)
 


### PR DESCRIPTION
## Summary

Clean replacement for #120 (which has merge conflicts against the current `main`).

Upgrades `@hey-api/client-fetch` from **0.12.0 to 0.13.1** (minor version bump).
No migration required. All 51 tests pass.

---

## Is this a breaking change?

**No.** `@hey-api/client-fetch` is a `devDependency` that is **not imported anywhere in the source code**. It is listed for a future migration to the new Fetch client (see the TODO comment in `openapi-ts.config.ts`). Zero runtime impact on the published package.

---

## Changes in 0.13.0 – 0.13.1

- **0.13.0**: feat: export `buildClientParams` function — new additive export, nothing removed
- **0.13.1**: fix: do not serialize path param name in URL — bug fix

---

## Changes

- `package.json`: specifier bumped `^0.12.0` → `^0.13.0`
- `pnpm-lock.yaml`: lockfile updated — `@hey-api/client-fetch` resolves to `0.13.1`

---

Supersedes: #120