### PR TITLE
chore(deps): upgrade aws-jwt-verify 5.1.0 to 5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@kinde/jwt-decoder": "^0.2.0",
-    "aws-jwt-verify": "^5.0.0",
+    "aws-jwt-verify": "^5.1.1",
     "dotenv": "^17.0.0"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       aws-jwt-verify:
-        specifier: ^5.0.0
-        version: 5.1.0
+        specifier: ^5.1.1
+        version: 5.1.1
       dotenv:
         specifier: ^17.0.0
         version: 17.3.1
@@ -61,6 +61,11 @@ packages:
 
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -589,8 +594,8 @@ packages:
   ast-v8-to-istanbul@0.3.11:
     resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
 
-  aws-jwt-verify@5.1.0:
-    resolution: {integrity: sha512-98ioOBMyrLU5jW5rPvkJo20XlNB2rAX3tZR3BM6AamfBkOoSRLV1EyGkbgHQzgFOWyQ7yV8+tce6M24rOpMkgw==}
+  aws-jwt-verify@5.1.1:
+    resolution: {integrity: sha512-j6whGdGJmQ27agk4ijY8RPv6itb8JLb7SCJ86fEnneTcSBrpxuwL8kLq6y5WVH95aIknyAloEqAsaOLS1J8ITQ==}
     engines: {node: '>=18.0.0'}
 
   balanced-match@1.0.2:
@@ -1167,6 +1172,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+    optional: true
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
@@ -1615,7 +1625,7 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  aws-jwt-verify@5.1.0: {}
+  aws-jwt-verify@5.1.1: {}
 
   balanced-match@1.0.2: {}
 
@@ -1834,7 +1844,7 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
     optional: true


### PR DESCRIPTION
## Summary

Clean replacement for #119 (which has merge conflicts against the current `main`).

Upgrades `aws-jwt-verify` from **5.1.0 to 5.1.1** (patch bump). Runtime dependency.
No migration required. All 51 tests pass.

---

## Is this a breaking change?

**No.** This is a patch release. All changes are additive or internal:

- **feat**: support GovCloud ALB ARNs in `AlbJwtVerifier` — new additive feature, nothing removed or changed
- **fix**: UI test works again after Cypress upgrade — internal test fix
- **docs**: tweak ALB docs
- **chore**: bump `form-data` in internal test fixtures (security fix in the library's own test suite, not runtime code)

---

## Changes

- `package.json`: specifier updated `^5.0.0` → `^5.1.1` (pnpm update also bumped the lower bound to the resolved version)
- `pnpm-lock.yaml`: lockfile updated — `aws-jwt-verify` resolves to `5.1.1`

---

Supersedes: #119